### PR TITLE
feat: 添加 Telegram 群组链接

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ url: "http://cdlug.org" # the base hostname & protocol for your site
 twitter_username: cdlug
 github_username:  cdlug
 google_groupname:  cdlug_community
+telegram_group_slug: cdlug2020
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,12 @@
 <footer class="site-footer">
-    <a href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io"><i class="fa fa-github-alt fa-2x"></i></a>
+    <a href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io"><i
+            class="fa fa-github-alt fa-2x"></i></a>
     <a href="mailto:{{ site.email }}"><i class="fa fa-envelope fa-2x"></i></a>
     <a href="https://twitter.com/{{ site.twitter_username }}"><i class="fa fa-twitter fa-2x"></i></a>
     <a href="https://groups.google.com/forum/#!forum/{{ site.google_groupname }}"><i class="fa fa-google fa-2x"></i></a>
-    <a href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}"><i class="fa fa-rss-square fa-2x" aria-hidden="true"></i></a>
+    <a href="https://t.me/{{ site.telegram_group_slug }}"><i class="fa fa-paper-plane fa-2x"></i></a>
+    <a href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}"><i class="fa fa-rss-square fa-2x"
+            aria-hidden="true"></i></a>
     <div class="inner">
         <section class="copyright">This theme copyright by <a href="http://scotthsmith.com">Scott Smith</a></section>
     </div>


### PR DESCRIPTION
好像线上用的 Font-Awesome 版本没有 Telegram Logo，我就找了一个纸飞机图标（
反正也很像）